### PR TITLE
feat(DELPHIN-1481): Apply LazyCatalog to all images

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Category/Images.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Category/Images.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+use Divante_VueStorefrontIndexer_Api_DatasourceInterface as DataSourceInterface;
+
+class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Images implements DataSourceInterface
+{
+
+    /**
+     * @var Ambimax_LazyCatalogImages_Model_Catalog_Image
+     */
+    protected $_lazyCatalog;
+
+    /**
+     * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Links constructor.
+     */
+    public function __construct()
+    {
+        $this->_lazyCatalog = Mage::getModel('ambimax_lazycatalogimages/catalog_image');
+        $this->_lazyCatalog
+            ->setHeight(180)
+            ->setWidth(180)
+            ->setTransparency();
+    }
+
+    /**
+     * @param array $indexData
+     * @param int $storeId
+     * @return array
+     */
+    public function addData(array $indexData, $storeId): array // @codingStandardsIgnoreLine
+    {
+        foreach ($indexData as $categoryId => $category) {
+            $indexData[$categoryId]['thumbnail'] = $this->_lazyCatalog
+                ->setImagePath($category['thumbnail'])
+                ->setImageName($category['name'])
+                ->getImageUrl();
+        }
+        return $indexData;
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Images.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Images.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+use Divante_VueStorefrontIndexer_Api_DatasourceInterface as DataSourceInterface;
+
+class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Images implements DataSourceInterface
+{
+
+    /**
+     * @var Ambimax_LazyCatalogImages_Model_Catalog_Image
+     */
+    protected $_lazyCatalog;
+
+    /**
+     * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Links constructor.
+     */
+    public function __construct()
+    {
+        $this->_lazyCatalog = Mage::getModel('ambimax_lazycatalogimages/catalog_image');
+        $this->_lazyCatalog
+            ->setHeight(180)
+            ->setWidth(180);
+    }
+
+    /**
+     * @param array $indexData
+     * @param int $storeId
+     * @return array
+     */
+    public function addData(array $indexData, $storeId): array // @codingStandardsIgnoreLine
+    {
+        foreach ($indexData as $productId => $product) {
+            $indexData[$productId]['image'] = $this->_lazyCatalog
+                ->setImagePath($product['image'])
+                ->setImageName($product['name'])
+                ->getImageUrl();
+            $indexData[$productId]['small_image'] = $this->_lazyCatalog
+                ->setImagePath($product['small_image'])
+                ->setImageName($product['name'])
+                ->getImageUrl();
+            $indexData[$productId]['thumbnail'] = $this->_lazyCatalog
+                ->setImagePath($product['thumbnail'])
+                ->setImageName($product['name'])
+                ->getImageUrl();
+        }
+        return $indexData;
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/etc/config.xml
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/etc/config.xml
@@ -207,6 +207,7 @@
                                 <attributes_data>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes</attributes_data>
                                 <grid_per_page>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Gridperpage</grid_per_page>
                                 <transaction_key>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Transactionkey</transaction_key>
+                                <image_data>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Images</image_data>
                             </datasources>
                         </category>
                         <product>
@@ -224,6 +225,7 @@
                                 <!--should be load last, or at least after attributes and configurable data has been loaded-->
                                 <meta_attributes>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Metaattributes</meta_attributes>
                                 <productdata>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Salespromotion_ProductSoldAmount</productdata>
+                                <image_data>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Images</image_data>
                             </datasources>
                         </product>
                         <cms_block>


### PR DESCRIPTION
This PR will adjust the indexing of images.
All images of products and categories will have the CDN URL, so VSF won't display broken images anymore.