### PR TITLE
fix(DELPHIN-1481): Fix thumbnail image in products

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Images.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Images.php
@@ -16,9 +16,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Images imple
     public function __construct()
     {
         $this->_lazyCatalog = Mage::getModel('ambimax_lazycatalogimages/catalog_image');
-        $this->_lazyCatalog
-            ->setHeight(180)
-            ->setWidth(180);
+        $this->_lazyCatalog;
     }
 
     /**
@@ -40,6 +38,8 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Images imple
             $indexData[$productId]['thumbnail'] = $this->_lazyCatalog
                 ->setImagePath($product['thumbnail'])
                 ->setImageName($product['name'])
+                ->setHeight(180)
+                ->setWidth(180)
                 ->getImageUrl();
         }
         return $indexData;


### PR DESCRIPTION
## Changes

This PR will fix the different sizes of product images.
Before this change the sizes were all set to `180x180` and with this PR only the thumbnail will get this size.
The other images wont get a size in its URL so the original image will be available.

Ticket: [DELPHIN-1481](https://ambimax.atlassian.net/browse/DELPHIN-1481)
