### PR TITLE
fix(DELPHIN-1481): Add 'sortierung' field to es mappings

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Product.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Product.php
@@ -66,9 +66,11 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Product extends AbstractM
 
             $attributesMapping['final_price'] = ['type' => FieldInterface::TYPE_DOUBLE];
             $attributesMapping['regular_price'] = ['type' => FieldInterface::TYPE_DOUBLE];
+            
+            $attributesMapping['sortierung'] = ['type' => FieldInterface::TYPE_INTEGER];
 
             $properties = $this->getCustomProperties();
-
+            
             $properties = array_merge($properties, $attributesMapping);
             $properties = array_merge($properties, $generalMapping->getCommonProperties());
 


### PR DESCRIPTION
This PR will add the <kbd>sortierung</kbd> field to the es mappings. I think this will finally solve the problem we are having with the failing staging deployment. As always, this stuff was not documented at all in the vue storefront documentation...